### PR TITLE
Update MSI_DrugBases.xml

### DIFF
--- a/1.3/Defs/Drugs/MSI_DrugBases.xml
+++ b/1.3/Defs/Drugs/MSI_DrugBases.xml
@@ -148,6 +148,7 @@
 		<defaultLabelColor>(1,0,0.5)</defaultLabelColor>
 		<scenarioCanAdd>true</scenarioCanAdd>
 		<maxSeverity>1.15</maxSeverity>
+		<chemical>SLI_Smokeleaf</chemical>
 		<isBad>false</isBad>
 		<comps>
 			<li Class="HediffCompProperties_Effecter">

--- a/1.3/Patches/Ideo_Patches.xml
+++ b/1.3/Patches/Ideo_Patches.xml
@@ -1,51 +1,55 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 
-    <Operation Class="PatchOperationSequence">
-		<operations>
-			<li Class="PatchOperationSetName">
-				<xpath>/Defs/ThingDef[defName="Burnbong"]/costList/SmokeleafLeaves</xpath>
-					<name>SmokeleafBuds</name>
-			</li>
-			<li Class="PatchOperationSetName">
-				<xpath>/Defs/ThingDef[defName="Burnbong"]/killedLeavings/SmokeleafLeaves</xpath>
-					<name>SmokeleafBuds</name>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="Burnbong"]/comps/li[@Class="CompProperties_RitualHediffGiverInRoom"]/hediff</xpath>
-				<value>
-					<hediff>SLI_SmokeleafHigh</hediff>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="Burnbong"]/comps/li[@Class="CompProperties_RitualHediffGiverInRoom"]/severity</xpath>
-				<value>
-					<severity>0.25</severity>
-				</value>
-			</li>
-			<li Class="PatchOperationSetName">
-				<xpath>/Defs/ThingDef[defName="Autobong"]/costList/SmokeleafLeaves</xpath>
-					<name>SmokeleafBuds</name>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="Autobong"]/comps/li[@Class="CompProperties_Refuelable"]/fuelFilter/thingDefs/li</xpath>
-				<value>
-					<li>SmokeleafBuds</li>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="Autobong"]/comps/li[@Class="CompProperties_GiveHediffSeverity"]/hediff</xpath>
-				<value>
-					<hediff>SLI_SmokeleafHigh</hediff>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="Autobong"]/comps/li[@Class="CompProperties_GiveHediffSeverity"]/severityPerSecond</xpath>
-				<value>
-					<severityPerSecond>0.025</severityPerSecond>
-				</value>
-			</li>
-		</operations>
-    </Operation>
-
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Ideology</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationSetName">
+					<xpath>/Defs/ThingDef[defName="Burnbong"]/costList/SmokeleafLeaves</xpath>
+						<name>SmokeleafBuds</name>
+				</li>
+				<li Class="PatchOperationSetName">
+					<xpath>/Defs/ThingDef[defName="Burnbong"]/killedLeavings/SmokeleafLeaves</xpath>
+						<name>SmokeleafBuds</name>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Burnbong"]/comps/li[@Class="CompProperties_RitualHediffGiverInRoom"]/hediff</xpath>
+					<value>
+						<hediff>SLI_SmokeleafHigh</hediff>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Burnbong"]/comps/li[@Class="CompProperties_RitualHediffGiverInRoom"]/severity</xpath>
+					<value>
+						<severity>0.25</severity>
+					</value>
+				</li>
+				<li Class="PatchOperationSetName">
+					<xpath>/Defs/ThingDef[defName="Autobong"]/costList/SmokeleafLeaves</xpath>
+						<name>SmokeleafBuds</name>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Autobong"]/comps/li[@Class="CompProperties_Refuelable"]/fuelFilter/thingDefs/li</xpath>
+					<value>
+						<li>SmokeleafBuds</li>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Autobong"]/comps/li[@Class="CompProperties_GiveHediffSeverity"]/hediff</xpath>
+					<value>
+						<hediff>SLI_SmokeleafHigh</hediff>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Autobong"]/comps/li[@Class="CompProperties_GiveHediffSeverity"]/severityPerSecond</xpath>
+					<value>
+						<severityPerSecond>0.025</severityPerSecond>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
 </Patch>


### PR DESCRIPTION
Add SLI_Smokeleaf chemical def to the SLI_SmokeleafHigh hediff to ensure compatibility with non-traditionally applied smokeleaf effects such as the Autobong and Burnbong.